### PR TITLE
Add test to check num_clusters functionality

### DIFF
--- a/src/test_pcst_fast.py
+++ b/src/test_pcst_fast.py
@@ -21,3 +21,18 @@ def test_simple2():
   result_nodes, result_edges = pcst_fast.pcst_fast(edges, prizes, costs, 0, 1, 'none', 0)
   npt.assert_array_equal(sorted(result_nodes), [0, 1, 2])
   npt.assert_array_equal(sorted(result_edges), [0, 1])
+
+
+def test_num_clusters():
+  """
+  create a graph as follows:
+  0---1---2---3
+      |   |   |
+      4   5   6
+  """
+  edges = [[0, 1], [1, 2], [1, 4],[2, 3], [2, 5], [3,6]]
+  prizes = [100., 0., 0., 0., 100., 100., 100.]
+  costs = [10., 100., 10., 10., 10., 10.]
+  result_nodes, result_edges = pcst_fast.pcst_fast(edges, prizes, costs, -1, 2, 'strong' , 0)
+  npt.assert_array_equal(sorted(result_nodes), [0, 1, 2, 3, 4, 5, 6])
+  npt.assert_array_equal(sorted(result_edges), [0, 2, 3, 4, 5])


### PR DESCRIPTION
One edge in the graph has much larger cost so it is expected that it should be left out when solving for two clusters.